### PR TITLE
namespace local storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ module.exports = React.createClass({
 
     return {
       color: this.getColor(color),
-      mode: ls.get('mode') ? ls.get('mode') : 'rgb',
-      colorMode: ls.get('colorMode') ? ls.get('colorMode') : 'h'
+      mode: ls.get('reactColorPickrMode') ? ls.get('reactColorPickrMode') : 'rgb',
+      colorMode: ls.get('reactColorPickrColorMode') ? ls.get('reactColorPickrColorMode') : 'h'
     };
   },
 
@@ -163,12 +163,12 @@ module.exports = React.createClass({
   },
 
   colorMode: function(mode) {
-    ls.set('colorMode', mode);
+    ls.set('reactColorPickrColorMode', mode);
     this.setState({colorMode: mode});
   },
 
   setMode: function(e) {
-    ls.set('mode', e.target.value);
+    ls.set('reactColorPickrMode', e.target.value);
     this.setState({mode: e.target.value});
   },
 


### PR DESCRIPTION
since localStorage is global across an entire website, for example `http://mapbox.com` having knowledge of the `mode` and `colorMode` of the color picker hosted on `https://www.mapbox.com/react-colorpickr/example/` I think that the color picker should avoid using generic words like `mode` and instead namespace to the module since a value that is unexpected by the module will break the module/application the module is embedded in. 

Validation of these properties would help as well. let me know what you think.
