### PR TITLE
Use react-range for input sliders to support IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var React = require('react');
 var { parseCSSColor } = require('csscolorparser');
 var extend = require('xtend');
+var Range = require('react-range');
 
 var XYControl = require('./src/xy');
 
@@ -270,7 +271,7 @@ module.exports = React.createClass({
                 onChange={this._onXYChange.bind(null, colorAttribute)} />
             </div>
             <div className={`cp-colormode-slider cp-colormode-attribute-slider ${colorAttribute}`}>
-              <input
+              <Range
                 value={colorAttributeValue}
                 style={hueSlide}
                 onChange={this._onColorSliderChange.bind(null, colorAttribute)}
@@ -388,7 +389,7 @@ module.exports = React.createClass({
               </fieldset>
             </div>
             <fieldset className='cp-fill-tile'>
-              <input
+              <Range
                 className='cp-alpha-slider-input'
                 value={a}
                 onChange={this._onAlphaSliderChange}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-react": "^2.2.0",
     "react-hot-loader": "^1.2.9",
     "smokestack": "^3.3.0",
-    "tap-closer": "^1.0.0",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.20",
     "webpack": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
     "react": "^0.13.3",
-    "react-range": "0.0.1",
+    "react-range": "0.0.3",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ]
   },
   "scripts": {
-    "test": "npm run lint && browserify test/test.js | tap-closer | smokestack -b firefox",
+    "test": "npm run lint && browserify test/test.js | tap-closer | smokestack -b firefox | tap-status",
     "lint": "eslint --no-eslintrc -c .eslintrc index.js src",
     "start": "node server.js",
     "build": "NODE_ENV=production browserify example/index.js | uglifyjs -c -m > example/bundle.js"
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^2.2.0",
     "react-hot-loader": "^1.2.9",
     "smokestack": "^3.3.0",
+    "tap-status": "^1.0.1",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.20",
     "webpack": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
     "react": "^0.13.3",
-    "react-range": "0.0.3",
+    "react-range": "0.0.5",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
     "react": "^0.13.3",
+    "react-range": "0.0.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -221,3 +221,11 @@ test('rgba value', (t) => {
   t.deepEqual(onChangeObj, expectOnChangeToBe, 'onChange object reflects options passed');
   t.end();
 });
+
+// close the smokestack window once tests are complete
+test('shutdown', function(t) {
+  t.end();
+  setTimeout(function() {
+    window.close();
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -82,15 +82,15 @@ test('component basics', (t) => {
   t.equal(colorSlider.classList.contains('v'), true, 'slider for value is present when HSV (v) input is in focus.');
 
   colorSliderInput.value = 0;
-  TestUtils.Simulate.change(colorSliderInput);
+  TestUtils.Simulate.click(colorSliderInput);
 
   t.equal(v.value, '0', 'HSV (v) input attribute changed to 0 after adjusting the color slider');
-  TestUtils.Simulate.change(v);
+  TestUtils.Simulate.click(v);
 
   t.equal(hex.value, '000000', 'input updates HEX to #000000');
 
   alphaSliderInput.value = 50;
-  TestUtils.Simulate.change(alphaSliderInput);
+  TestUtils.Simulate.click(alphaSliderInput);
   t.equal(onChangeObj.a, 0.5, 'alpha output is adjusted');
 
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,7 @@ test('component options', (t) => {
     b: 0,
     a: 1,
     hex: '000',
+    input: 'hex',
     mode: 'hsv',
     colorAttribute: 'g'
   };
@@ -176,6 +177,7 @@ test('rgb value', (t) => {
     b: 255,
     a: 1,
     hex: '0ff',
+    input: 'hex',
     mode: 'rgb',
     colorAttribute: 'h'
   };
@@ -212,6 +214,7 @@ test('rgba value', (t) => {
     a: 0.5,
     hex: '0ff',
     mode: 'rgb',
+    input: 'hex',
     colorAttribute: 'h'
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -201,8 +201,7 @@ test('rgba value', (t) => {
   );
 
   t.ok(colorpickr, 'colorpickr component with options is rendered in document');
-
-  TestUtils.Simulate.change(TestUtils.findRenderedDOMComponentWithClass(colorpickr, 'cp-hex-input').getDOMNode());
+  TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithClass(colorpickr, 'cp-mode-hsv').getDOMNode());
 
   const expectOnChangeToBe = {
     h: 180,
@@ -213,8 +212,7 @@ test('rgba value', (t) => {
     b: 255,
     a: 0.5,
     hex: '0ff',
-    mode: 'rgb',
-    input: 'hex',
+    mode: 'hsv',
     colorAttribute: 'h'
   };
 


### PR DESCRIPTION
Right now, react-colorpickr does [not support IE](https://github.com/facebook/react/issues/554) because the onChange event is not fired IE when using input type=range. This swaps out regular input ranges with [`react-range`](https://github.com/mapbox/react-range) which works around this issue.

/cc @tmcw @tristen 
