### PR TITLE
update to react 0.14 and babel 6.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "stage": 0,
-  "loose": "all"
+  presets: ["es2015", "react"]
 }

--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var ColorPicker = require('../');
 
 // Output fill that's outside of the react app.
@@ -39,4 +40,4 @@ var App = React.createClass({
 
 });
 
-React.render(<App/>, document.getElementById('app'));
+ReactDOM.render(<App/>, document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
     "react": "^0.14.2",
+    "react-dom": "^0.14.2",
     "react-range": "github:lokeh/react-range",
     "xtend": "^4.0.0"
   },
@@ -41,7 +42,6 @@
     "browserify": "^9.0.8",
     "eslint": "^0.20.0",
     "eslint-plugin-react": "^2.2.0",
-    "react-dom": "^0.14.2",
     "react-hot-loader": "^1.2.9",
     "smokestack": "^3.3.0",
     "tap-status": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "babel-core": "^5.8.22",
+    "babel-core": "^6.0.20",
     "babel-eslint": "^3.0.1",
-    "babel-loader": "^5.3.2",
+    "babel-loader": "^6.0.1",
+    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-react": "^6.0.15",
     "babelify": "^6.0.2",
     "browserify": "^9.0.8",
     "eslint": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "clamp": "^1.0.1",
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
-    "react": "^0.13.3",
-    "react-range": "0.0.5",
+    "react": "^0.14.2",
+    "react-range": "github:lokeh/react-range",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
@@ -41,6 +41,7 @@
     "browserify": "^9.0.8",
     "eslint": "^0.20.0",
     "eslint-plugin-react": "^2.2.0",
+    "react-dom": "^0.14.2",
     "react-hot-loader": "^1.2.9",
     "smokestack": "^3.3.0",
     "tap-status": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "csscolorparser": "^1.0.2",
     "react": "^0.14.2",
     "react-dom": "^0.14.2",
-    "react-range": "github:lokeh/react-range",
+    "react-range": "0.0.6",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/src/xy.js
+++ b/src/xy.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var clamp = require('clamp');
 
 var XYControl = React.createClass({
@@ -25,7 +26,7 @@ var XYControl = React.createClass({
     });
   },
   getOwnBoundingRect() {
-    return React.findDOMNode(this).getBoundingClientRect();
+    return ReactDOM.findDOMNode(this).getBoundingClientRect();
   },
   _onMouseDown(e) {
     var rect = this.getOwnBoundingRect();


### PR DESCRIPTION
This is a pull request to update this package to react 0.14.x.

This pull request is dependent on `react-range` also updating to the latest version in it's `package.json`: https://github.com/mapbox/react-range/pull/9.

Once the above pull request is accepted I'll update this one with the appropriate `react-range` version.
