### PR TITLE
Remove hard dependency on React

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var React = require('react');
 var extend = require('xtend');
-var Range = require('react-range');
 
 var XYControl = require('./src/xy');
 var { parseCSSColor } = require('csscolorparser');
@@ -254,7 +253,8 @@ module.exports = React.createClass({
                 onChange={this._onXYChange.bind(null, colorAttribute)} />
             </div>
             <div className={`cp-colormode-slider cp-colormode-attribute-slider ${colorAttribute}`}>
-              <Range
+              <input
+                type='range'
                 value={colorAttributeValue}
                 style={hueSlide}
                 onChange={this._onColorSliderChange.bind(null, colorAttribute)}
@@ -419,7 +419,8 @@ module.exports = React.createClass({
               </fieldset>
             </div>
             <fieldset className='cp-fill-tile'>
-              <Range
+              <input
+                type='range'
                 className='cp-alpha-slider-input'
                 value={a}
                 onChange={this._onAlphaSliderChange}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "clamp": "^1.0.1",
     "colr-convert": "^1.0.4",
     "csscolorparser": "^1.0.2",
-    "react": "^0.13.3",
-    "react-range": "0.0.5",
     "xtend": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": "0.13.x || 0.14.x"
   },
   "devDependencies": {
     "babel-core": "^5.8.22",
@@ -41,6 +42,7 @@
     "browserify": "^9.0.8",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.11.2",
+    "react": "^0.13.3",
     "react-hot-loader": "^1.2.9",
     "smokestack": "^3.3.0",
     "tap-status": "^1.0.1",

--- a/test/component.js
+++ b/test/component.js
@@ -89,15 +89,15 @@ test('component basics', (t) => {
   t.equal(colorSlider.classList.contains('v'), true, 'slider for value is present when HSV (v) input is in focus.');
 
   colorSliderInput.value = 0;
-  TestUtils.Simulate.click(colorSliderInput);
+  TestUtils.Simulate.change(colorSliderInput);
 
   t.equal(vInput.value, '0', 'HSV (v) input attribute changed to 0 after adjusting the color slider');
-  TestUtils.Simulate.click(vInput);
+  TestUtils.Simulate.change(vInput);
 
   t.equal(hex.value, '000000', 'input updates HEX to #000000');
 
   alphaSliderInput.value = 50;
-  TestUtils.Simulate.click(alphaSliderInput);
+  TestUtils.Simulate.change(alphaSliderInput);
   t.equal(onChangeObj.a, 0.5, 'alpha output is adjusted');
 
   t.end();


### PR DESCRIPTION
Moving react dependency to a peerDependency that will require that React
is installed, but will not install it transitively. This will allow
consumers to upgrade to React 0.14.

Also removing dependency on react-range. Supporting IE isn't worth the
side-effects.
