### PR TITLE
Add second parameter to overrideValue

### DIFF
--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -76,10 +76,16 @@ class ColorPickr extends React.Component {
     return v.trim();
   }
 
-  overrideValue = cssColor => {
-    this.setState({
+  overrideValue = (cssColor, shouldUpdateInitialValue) => {
+    const state = {
       color: getColor(cssColor)
-    }, this.emitOnChange);
+    };
+
+    if (shouldUpdateInitialValue) {
+      state.initialValue = cssColor;
+    }
+
+    this.setState(state, this.emitOnChange);
   };
 
   emitOnChange = hexInput => {

--- a/test/jest/colorpickr.jest.js
+++ b/test/jest/colorpickr.jest.js
@@ -105,6 +105,26 @@ describe('Colorpickr', () => {
         mode: 'hsl',
         channel: 'h'
       });
+      expect(wrapper.instance().state.initialValue).toEqual('#000');
+    });
+
+    test('overrideValue with true as second argument sets overrides initialValue', () => {
+      wrapper.instance().overrideValue('red', true);
+      expect(testCase.props.onChange).toHaveBeenCalledTimes(1);
+      expect(testCase.props.onChange).toHaveBeenCalledWith({
+        h: 0,
+        s: 100,
+        l: 50,
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+        hexInput: false,
+        hex: 'ff0000',
+        mode: 'hsl',
+        channel: 'h'
+      });
+      expect(wrapper.instance().state.initialValue).toEqual('red');
     });
   });
 


### PR DESCRIPTION
Parameter should be a boolean. When true, the override value also updates the initialValue. This is helpful for setting a new reset value to the color picker.