### PR TITLE
Fix picker events handling

### DIFF
--- a/src/xy.js
+++ b/src/xy.js
@@ -7,8 +7,6 @@ import themeable from 'react-themeable';
 import { autokey } from './autokey';
 import clamp from 'clamp';
 
-const isMobile = typeof document != 'undefined' && 'ontouchstart' in document;
-
 class XYControl extends React.Component {
   _isMounted = false;
 
@@ -64,8 +62,11 @@ class XYControl extends React.Component {
       offset: { x, y }
     });
 
-    window.addEventListener(isMobile ? 'touchmove' : 'mousemove', this._drag);
-    window.addEventListener(isMobile ? 'touchend' : 'mouseup', this._dragEnd);
+    window.addEventListener('mousemove', this._drag);
+    window.addEventListener('mouseup', this._dragEnd);
+
+    window.addEventListener('touchmove', this._drag);
+    window.addEventListener('touchend', this._dragEnd);
   };
 
   _drag = e => {
@@ -82,8 +83,11 @@ class XYControl extends React.Component {
   };
 
   _dragEnd = () => {
-    window.removeEventListener(isMobile ? 'touchmove' : 'mousemove', this._drag);
-    window.removeEventListener(isMobile ? 'touchend' : 'mouseup', this._dragEnd);
+    window.removeEventListener('mousemove', this._drag);
+    window.removeEventListener('mouseup', this._dragEnd);
+
+    window.removeEventListener('touchmove', this._drag);
+    window.removeEventListener('touchend', this._dragEnd);
   };
 
   render() {

--- a/src/xy.js
+++ b/src/xy.js
@@ -46,8 +46,8 @@ class XYControl extends React.Component {
     e.preventDefault();
     if (!this._isMounted) return;
     const rect = this.getOwnBoundingRect();
-    const x = isMobile ? e.changedTouches[0].clientX : e.clientX;
-    const y = isMobile ? e.changedTouches[0].clientY : e.clientY;
+    const x = e.changedTouches ? e.changedTouches[0].clientX : e.clientX;
+    const y = e.changedTouches ? e.changedTouches[0].clientY : e.clientY;
 
     const offset = {
       left: x - rect.left,
@@ -73,10 +73,10 @@ class XYControl extends React.Component {
     e.preventDefault();
     const { start, offset } = this.state;
     const top =
-      (isMobile ? e.changedTouches[0].clientY : e.clientY) +
+      (e.changedTouches ? e.changedTouches[0].clientY : e.clientY) +
       start.y - offset.y;
     const left =
-      (isMobile ? e.changedTouches[0].clientX : e.clientX) +
+      (e.changedTouches ? e.changedTouches[0].clientX : e.clientX) +
       start.x - offset.x;
 
     this.change({ top, left });


### PR DESCRIPTION
Fixes #106 

In this PR I removed `isMobile` check - in case of laptop with touchscreen both mouse and touch events should work. So I'm always listening for both touch **and** mouse events.

Instead of using `isMobile` inside event handlers, I'm checking if `e.changedTouches` is present.
If so - it's touch event, otherwise I interpret it as mouse event.

Tested on:
- Chrome and Firefox on Linux
- Chrome, Edge and IE11 on Windows