### PR TITLE
Move to labs.mapbox.com

### DIFF
--- a/.artifacts.yml
+++ b/.artifacts.yml
@@ -1,0 +1,3 @@
+version: v1
+defaults:
+  - publisher

--- a/example/index.html
+++ b/example/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>React colorpickr</title>
+  <link rel="canonical" href="https://labs.mapbox.com/react-colorpickr/" >
   <link rel='shortcut icon' href='https://mapbox.com/img/favicon.ico' type='image/x-icon' />
   <link href="https://api.mapbox.com/mapbox-assembly/mbx/v0.24.0/assembly.min.css" rel="stylesheet">
   <script src="https://api.mapbox.com/mapbox-assembly/mbx/v0.24.0/assembly.js"></script>


### PR DESCRIPTION
As discussed in https://github.com/mapbox/frontend-platform-team/issues/44, we are planning to move this repository the `labs` subdomain.
 
This PR adds:
- A canonical link to help search engines discern between duplicates and the original  `labs.mapbox.com/react-colorpickr`.
- Added `.artifacts.yml` to allow for publishing via Publisher.