### PR TITLE
Add readOnly prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ render() {
 }
 ```
 
+#### `readOnly`
+
+If `readOnly` is provided with a value of `true`, the colorpicker will render in a readonly state with values clearly shown and selectable, but not editable.
+
 ## Developing
 
     npm install & npm start

--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,8 +2397,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2419,14 +2418,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2441,20 +2438,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2571,8 +2565,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2584,7 +2577,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2599,7 +2591,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2607,14 +2598,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2633,7 +2622,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2723,8 +2711,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2736,7 +2723,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2822,8 +2808,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2859,7 +2844,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2879,7 +2863,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2923,14 +2906,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4753,8 +4734,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4775,14 +4755,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4797,20 +4775,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4927,8 +4902,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4940,7 +4914,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4955,7 +4928,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4963,14 +4935,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4989,7 +4959,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5070,8 +5039,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5083,7 +5051,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5169,8 +5136,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5206,7 +5172,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5226,7 +5191,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5270,14 +5234,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11706,8 +11668,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11728,14 +11689,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11750,20 +11709,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11880,8 +11836,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11893,7 +11848,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11908,7 +11862,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -11916,14 +11869,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11942,7 +11893,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12032,8 +11982,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12045,7 +11994,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12131,8 +12079,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12168,7 +12115,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -12188,7 +12134,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12232,14 +12177,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -32,7 +32,6 @@ const isHSLMode = c => c === 'h' || c === 's' || c === 'l';
 
 class ColorPickr extends React.Component {
   modeInputName = !process.env.TESTING ? `mode-${Math.random()}` : '';
-
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     channel: PropTypes.string,
@@ -92,7 +91,7 @@ class ColorPickr extends React.Component {
 
   emitOnChange = hexInput => {
     const { color, mode, channel } = this.state;
-    this.props.onChange({ hexInput: !!hexInput, mode, channel, ...color });
+    this.props.onChange({ hexInput: !!hexInput, mode, channel, ...color});
   };
 
   changeHSL = (p, inputValue) => {
@@ -130,9 +129,7 @@ class ColorPickr extends React.Component {
   };
 
   changeAlpha = (id, inputValue) => {
-    const nextColor = Object.assign({}, this.state.color, {
-      a: inputValue / 100
-    });
+    const nextColor = Object.assign({}, this.state.color, { a: inputValue / 100 });
     this.setState({ color: nextColor }, this.emitOnChange);
   };
 
@@ -141,7 +138,7 @@ class ColorPickr extends React.Component {
     const hex = `#${value}`;
     const isValid = colorString.get(hex);
     const color = getColor(hex) || this.state.color;
-    const nextColor = Object.assign({}, color, { hex: value });
+    const nextColor = Object.assign({}, color, { hex: value })
     this.setState({ color: nextColor }, () => {
       if (isValid) this.emitOnChange(true);
     });
@@ -175,7 +172,7 @@ class ColorPickr extends React.Component {
     color[channel] = value;
     if (isRGBMode(channel)) this.changeRGB(color);
     if (isHSLMode(channel)) this.changeHSL(color);
-  };
+  }
 
   onAlphaSliderChange = e => {
     const value = this.toNumber(e.target.value);
@@ -240,12 +237,8 @@ class ColorPickr extends React.Component {
     }
 
     const rgbaBackground = rgbaColor(r, g, b, a);
-    const opacityGradient = `linear-gradient(to right, ${rgbaColor(
-      r,
-      g,
-      b,
-      0
-    )}, ${rgbaColor(r, g, b, 100)})`;
+    const opacityGradient =
+      `linear-gradient(to right, ${rgbaColor(r, g, b, 0)}, ${rgbaColor(r, g, b, 100)})`;
 
     const hueBackground = `hsl(${h}, 100%, 50%)`;
 
@@ -262,17 +255,20 @@ class ColorPickr extends React.Component {
     let opacityLow = 0;
 
     if (['r', 'g', 'b'].indexOf(channel) >= 0) {
-      opacityHigh = Math.round((color[channel] / 255) * 100) / 100;
-      opacityLow = Math.round(100 - (color[channel] / 255) * 100) / 100;
+      opacityHigh = Math.round(color[channel] / 255 * 100) / 100;
+      opacityLow = Math.round(100 - color[channel] / 255 * 100) / 100;
     } else if (['s', 'l'].indexOf(channel) >= 0) {
-      opacityHigh = Math.round((color[channel] / 100) * 100) / 100;
-      opacityLow = Math.round(100 - (color[channel] / 100) * 100) / 100;
+      opacityHigh = Math.round(color[channel] / 100 * 100) / 100;
+      opacityLow = Math.round(100 - color[channel] / 100 * 100) / 100;
     }
 
     let modeInputs = (
       <div>
         <div
-          {...theme('inputModeContainer', `${channel === 'h' ? 'active' : ''}`)}
+          {...theme(
+            'inputModeContainer',
+            `${channel === 'h' ? 'active' : ''}`
+          )}
         >
           <ModeInput
             id="h"
@@ -291,7 +287,10 @@ class ColorPickr extends React.Component {
           />
         </div>
         <div
-          {...theme('inputModeContainer', `${channel === 's' ? 'active' : ''}`)}
+          {...theme(
+            'inputModeContainer',
+            `${channel === 's' ? 'active' : ''}`
+          )}
         >
           <ModeInput
             id="s"
@@ -310,7 +309,10 @@ class ColorPickr extends React.Component {
           />
         </div>
         <div
-          {...theme('inputModeContainer', `${channel === 'l' ? 'active' : ''}`)}
+          {...theme(
+            'inputModeContainer',
+            `${channel === 'l' ? 'active' : ''}`
+          )}
         >
           <ModeInput
             id="l"
@@ -335,10 +337,7 @@ class ColorPickr extends React.Component {
       modeInputs = (
         <div>
           <div
-            {...theme(
-              'inputModeContainer',
-              `${channel === 'r' ? 'active' : ''}`
-            )}
+            {...theme('inputModeContainer', `${channel === 'r' ? 'active' : ''}`)}
           >
             <ModeInput
               id="r"
@@ -357,10 +356,7 @@ class ColorPickr extends React.Component {
             />
           </div>
           <div
-            {...theme(
-              'inputModeContainer',
-              `${channel === 'g' ? 'active' : ''}`
-            )}
+            {...theme('inputModeContainer', `${channel === 'g' ? 'active' : ''}`)}
           >
             <ModeInput
               id="g"
@@ -466,13 +462,7 @@ class ColorPickr extends React.Component {
                 opacityHigh={opacityHigh}
               />
             </XYControl>
-            <div
-              {...theme(
-                'slider',
-                'colorModeSlider',
-                `colorModeSlider${channel.toUpperCase()}`
-              )}
-            >
+            <div {...theme('slider', 'colorModeSlider', `colorModeSlider${channel.toUpperCase()}`)}>
               <input
                 disabled={readOnly}
                 type="range"
@@ -549,10 +539,7 @@ class ColorPickr extends React.Component {
               </div>
             )}
             <div {...theme('tileBackground', 'newSwatchContainer')}>
-              <div
-                {...theme('swatch')}
-                style={{ backgroundColor: rgbaBackground }}
-              />
+            <div {...theme('swatch')} style={{ backgroundColor: rgbaBackground }} />
             </div>
           </div>
           <div {...theme('hexContainer')}>

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -49,7 +49,7 @@ class ColorPickr extends React.Component {
     mode: 'hsl',
     channel: 'h',
     theme: {},
-    readOnly: false
+    readOnly: true
   };
 
   constructor(props) {
@@ -200,6 +200,13 @@ class ColorPickr extends React.Component {
     const a = Math.round(color.a * 100);
 
     const themeObject = Object.assign({}, defaultTheme, this.props.theme);
+
+    if (!readOnly) {
+      themeObject.numberInput = `${themeObject.numberInput} bg-white`
+    } else {
+      themeObject.xyControlContainer = `${themeObject.xyControlContainer} events-none`
+    }
+
     const theme = autokey(themeable(themeObject));
 
     const themeRGBGradient = {
@@ -405,9 +412,7 @@ class ColorPickr extends React.Component {
               {...colorCoords(channel, color)}
               isDark={isDark([r, g, b]) ? '' : 'dark'}
               theme={{
-                xyControlContainer: `${
-                  themeObject.xyControlContainer
-                } ${readOnly && 'events-none'}`,
+                xyControlContainer: themeObject.xyControlContainer,
                 xyControl: themeObject.xyControl,
                 xyControlDark: themeObject.xyControlDark
               }}

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -276,14 +276,14 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 'h'}
             onChange={this.setChannel}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
           <HInput
             id="h"
             value={h}
             theme={themeNumberInput}
             onChange={this.changeHSL}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
         </div>
         <div
@@ -298,14 +298,14 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 's'}
             onChange={this.setChannel}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
           <SLAlphaInput
             id="s"
             value={s}
             theme={themeNumberInput}
             onChange={this.changeHSL}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
         </div>
         <div
@@ -320,14 +320,14 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 'l'}
             onChange={this.setChannel}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
           <SLAlphaInput
             id="l"
             value={l}
             theme={themeNumberInput}
             onChange={this.changeHSL}
-            readOnly={readOnly}
+            {...(readOnly ? { readOnly: true } : {})}
           />
         </div>
       </div>
@@ -345,14 +345,14 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'r'}
               onChange={this.setChannel}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
             <RGBInput
               id="r"
               theme={themeNumberInput}
               value={r}
               onChange={this.changeRGB}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
           </div>
           <div
@@ -364,14 +364,14 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'g'}
               onChange={this.setChannel}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
             <RGBInput
               id="g"
               value={g}
               theme={themeNumberInput}
               onChange={this.changeRGB}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
           </div>
           <div
@@ -386,14 +386,14 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'b'}
               onChange={this.setChannel}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
             <RGBInput
               id="b"
               theme={themeNumberInput}
               value={b}
               onChange={this.changeRGB}
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
             />
           </div>
         </div>
@@ -464,7 +464,7 @@ class ColorPickr extends React.Component {
             </XYControl>
             <div {...theme('slider', 'colorModeSlider', `colorModeSlider${channel.toUpperCase()}`)}>
               <input
-                disabled={readOnly}
+                {...(readOnly ? { disabled: true } : {})}
                 type="range"
                 value={color[channel]}
                 style={hueSlide}
@@ -475,7 +475,7 @@ class ColorPickr extends React.Component {
             </div>
             <div {...theme('slider', 'tileBackground')}>
               <input
-                disabled={readOnly}
+                {...(readOnly ? { disabled: true } : {})}
                 type="range"
                 value={a}
                 onChange={this.onAlphaSliderChange}
@@ -513,7 +513,7 @@ class ColorPickr extends React.Component {
             {modeInputs}
             <div {...theme('alphaContainer')}>
               <SLAlphaInput
-                readOnly={readOnly}
+                {...(readOnly ? { readOnly: true } : {})}
                 id={String.fromCharCode(945)}
                 value={a}
                 theme={themeNumberInput}
@@ -528,7 +528,7 @@ class ColorPickr extends React.Component {
               <div {...theme('tileBackground', 'currentSwatchContainer')}>
                 <button
                   {...theme('swatch', 'currentSwatch')}
-                  disabled={readOnly}
+                  {...(readOnly ? { disabled: true } : {})}
                   title="Reset color"
                   data-test="color-reset"
                   style={{ backgroundColor: initialValue }}
@@ -545,7 +545,7 @@ class ColorPickr extends React.Component {
           <div {...theme('hexContainer')}>
             <label {...theme('numberInputLabel')}>#</label>
             <input
-              readOnly={readOnly}
+              {...(readOnly ? { readOnly: true } : {})}
               {...theme('numberInput')}
               data-test="hex-input"
               value={hex}

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -32,14 +32,15 @@ const isHSLMode = c => c === 'h' || c === 's' || c === 'l';
 
 class ColorPickr extends React.Component {
   modeInputName = !process.env.TESTING ? `mode-${Math.random()}` : '';
-  
+
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     channel: PropTypes.string,
     theme: PropTypes.object,
     mode: PropTypes.string,
     initialValue: PropTypes.string,
-    reset: PropTypes.bool
+    reset: PropTypes.bool,
+    readOnly: PropTypes.bool
   };
 
   static defaultProps = {
@@ -47,7 +48,8 @@ class ColorPickr extends React.Component {
     reset: true,
     mode: 'hsl',
     channel: 'h',
-    theme: {}
+    theme: {},
+    readOnly: false
   };
 
   constructor(props) {
@@ -90,7 +92,7 @@ class ColorPickr extends React.Component {
 
   emitOnChange = hexInput => {
     const { color, mode, channel } = this.state;
-    this.props.onChange({ hexInput: !!hexInput, mode, channel, ...color});
+    this.props.onChange({ hexInput: !!hexInput, mode, channel, ...color });
   };
 
   changeHSL = (p, inputValue) => {
@@ -128,7 +130,9 @@ class ColorPickr extends React.Component {
   };
 
   changeAlpha = (id, inputValue) => {
-    const nextColor = Object.assign({}, this.state.color, { a: inputValue / 100 });
+    const nextColor = Object.assign({}, this.state.color, {
+      a: inputValue / 100
+    });
     this.setState({ color: nextColor }, this.emitOnChange);
   };
 
@@ -137,7 +141,7 @@ class ColorPickr extends React.Component {
     const hex = `#${value}`;
     const isValid = colorString.get(hex);
     const color = getColor(hex) || this.state.color;
-    const nextColor = Object.assign({}, color, { hex: value })
+    const nextColor = Object.assign({}, color, { hex: value });
     this.setState({ color: nextColor }, () => {
       if (isValid) this.emitOnChange(true);
     });
@@ -171,7 +175,7 @@ class ColorPickr extends React.Component {
     color[channel] = value;
     if (isRGBMode(channel)) this.changeRGB(color);
     if (isHSLMode(channel)) this.changeHSL(color);
-  }
+  };
 
   onAlphaSliderChange = e => {
     const value = this.toNumber(e.target.value);
@@ -192,6 +196,7 @@ class ColorPickr extends React.Component {
   render() {
     const { channel, color, mode, initialValue } = this.state;
     const { r, g, b, h, s, l, hex } = color;
+    const { readOnly } = this.props;
     const a = Math.round(color.a * 100);
 
     const themeObject = Object.assign({}, defaultTheme, this.props.theme);
@@ -228,8 +233,12 @@ class ColorPickr extends React.Component {
     }
 
     const rgbaBackground = rgbaColor(r, g, b, a);
-    const opacityGradient =
-      `linear-gradient(to right, ${rgbaColor(r, g, b, 0)}, ${rgbaColor(r, g, b, 100)})`;
+    const opacityGradient = `linear-gradient(to right, ${rgbaColor(
+      r,
+      g,
+      b,
+      0
+    )}, ${rgbaColor(r, g, b, 100)})`;
 
     const hueBackground = `hsl(${h}, 100%, 50%)`;
 
@@ -246,20 +255,17 @@ class ColorPickr extends React.Component {
     let opacityLow = 0;
 
     if (['r', 'g', 'b'].indexOf(channel) >= 0) {
-      opacityHigh = Math.round(color[channel] / 255 * 100) / 100;
-      opacityLow = Math.round(100 - color[channel] / 255 * 100) / 100;
+      opacityHigh = Math.round((color[channel] / 255) * 100) / 100;
+      opacityLow = Math.round(100 - (color[channel] / 255) * 100) / 100;
     } else if (['s', 'l'].indexOf(channel) >= 0) {
-      opacityHigh = Math.round(color[channel] / 100 * 100) / 100;
-      opacityLow = Math.round(100 - color[channel] / 100 * 100) / 100;
+      opacityHigh = Math.round((color[channel] / 100) * 100) / 100;
+      opacityLow = Math.round(100 - (color[channel] / 100) * 100) / 100;
     }
 
     let modeInputs = (
       <div>
         <div
-          {...theme(
-            'inputModeContainer',
-            `${channel === 'h' ? 'active' : ''}`
-          )}
+          {...theme('inputModeContainer', `${channel === 'h' ? 'active' : ''}`)}
         >
           <ModeInput
             id="h"
@@ -267,19 +273,18 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 'h'}
             onChange={this.setChannel}
+            readOnly={readOnly}
           />
           <HInput
             id="h"
             value={h}
             theme={themeNumberInput}
             onChange={this.changeHSL}
+            readOnly={readOnly}
           />
         </div>
         <div
-          {...theme(
-            'inputModeContainer',
-            `${channel === 's' ? 'active' : ''}`
-          )}
+          {...theme('inputModeContainer', `${channel === 's' ? 'active' : ''}`)}
         >
           <ModeInput
             id="s"
@@ -287,19 +292,18 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 's'}
             onChange={this.setChannel}
+            readOnly={readOnly}
           />
           <SLAlphaInput
             id="s"
             value={s}
             theme={themeNumberInput}
             onChange={this.changeHSL}
+            readOnly={readOnly}
           />
         </div>
         <div
-          {...theme(
-            'inputModeContainer',
-            `${channel === 'l' ? 'active' : ''}`
-          )}
+          {...theme('inputModeContainer', `${channel === 'l' ? 'active' : ''}`)}
         >
           <ModeInput
             id="l"
@@ -307,12 +311,14 @@ class ColorPickr extends React.Component {
             theme={themeModeInput}
             checked={channel === 'l'}
             onChange={this.setChannel}
+            readOnly={readOnly}
           />
           <SLAlphaInput
             id="l"
             value={l}
             theme={themeNumberInput}
             onChange={this.changeHSL}
+            readOnly={readOnly}
           />
         </div>
       </div>
@@ -322,7 +328,10 @@ class ColorPickr extends React.Component {
       modeInputs = (
         <div>
           <div
-            {...theme('inputModeContainer', `${channel === 'r' ? 'active' : ''}`)}
+            {...theme(
+              'inputModeContainer',
+              `${channel === 'r' ? 'active' : ''}`
+            )}
           >
             <ModeInput
               id="r"
@@ -330,16 +339,21 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'r'}
               onChange={this.setChannel}
+              readOnly={readOnly}
             />
             <RGBInput
               id="r"
               theme={themeNumberInput}
               value={r}
               onChange={this.changeRGB}
+              readOnly={readOnly}
             />
           </div>
           <div
-            {...theme('inputModeContainer', `${channel === 'g' ? 'active' : ''}`)}
+            {...theme(
+              'inputModeContainer',
+              `${channel === 'g' ? 'active' : ''}`
+            )}
           >
             <ModeInput
               id="g"
@@ -347,12 +361,14 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'g'}
               onChange={this.setChannel}
+              readOnly={readOnly}
             />
             <RGBInput
               id="g"
               value={g}
               theme={themeNumberInput}
               onChange={this.changeRGB}
+              readOnly={readOnly}
             />
           </div>
           <div
@@ -367,12 +383,14 @@ class ColorPickr extends React.Component {
               name={this.modeInputName}
               checked={channel === 'b'}
               onChange={this.setChannel}
+              readOnly={readOnly}
             />
             <RGBInput
               id="b"
               theme={themeNumberInput}
               value={b}
               onChange={this.changeRGB}
+              readOnly={readOnly}
             />
           </div>
         </div>
@@ -387,7 +405,9 @@ class ColorPickr extends React.Component {
               {...colorCoords(channel, color)}
               isDark={isDark([r, g, b]) ? '' : 'dark'}
               theme={{
-                xyControlContainer: themeObject.xyControlContainer,
+                xyControlContainer: `${
+                  themeObject.xyControlContainer
+                } ${readOnly && 'events-none'}`,
                 xyControl: themeObject.xyControl,
                 xyControlDark: themeObject.xyControlDark
               }}
@@ -441,8 +461,15 @@ class ColorPickr extends React.Component {
                 opacityHigh={opacityHigh}
               />
             </XYControl>
-            <div {...theme('slider', 'colorModeSlider', `colorModeSlider${channel.toUpperCase()}`)}>
+            <div
+              {...theme(
+                'slider',
+                'colorModeSlider',
+                `colorModeSlider${channel.toUpperCase()}`
+              )}
+            >
               <input
+                disabled={readOnly}
                 type="range"
                 value={color[channel]}
                 style={hueSlide}
@@ -453,6 +480,7 @@ class ColorPickr extends React.Component {
             </div>
             <div {...theme('slider', 'tileBackground')}>
               <input
+                disabled={readOnly}
                 type="range"
                 value={a}
                 onChange={this.onAlphaSliderChange}
@@ -490,6 +518,7 @@ class ColorPickr extends React.Component {
             {modeInputs}
             <div {...theme('alphaContainer')}>
               <SLAlphaInput
+                readOnly={readOnly}
                 id={String.fromCharCode(945)}
                 value={a}
                 theme={themeNumberInput}
@@ -500,25 +529,31 @@ class ColorPickr extends React.Component {
         </div>
         <div {...theme('bottomWrapper')}>
           <div {...theme('swatchCompareContainer')}>
-            {this.props.reset &&
+            {this.props.reset && (
               <div {...theme('tileBackground', 'currentSwatchContainer')}>
                 <button
                   {...theme('swatch', 'currentSwatch')}
+                  disabled={readOnly}
                   title="Reset color"
                   data-test="color-reset"
                   style={{ backgroundColor: initialValue }}
                   onClick={this.reset}
                 >
-                  Reset
+                  {`${readOnly ? '' : 'Reset'}`}
                 </button>
-              </div>}
+              </div>
+            )}
             <div {...theme('tileBackground', 'newSwatchContainer')}>
-              <div {...theme('swatch')} style={{ backgroundColor: rgbaBackground }} />
+              <div
+                {...theme('swatch')}
+                style={{ backgroundColor: rgbaBackground }}
+              />
             </div>
           </div>
           <div {...theme('hexContainer')}>
             <label {...theme('numberInputLabel')}>#</label>
             <input
+              readOnly={readOnly}
               {...theme('numberInput')}
               data-test="hex-input"
               value={hex}

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -49,7 +49,7 @@ class ColorPickr extends React.Component {
     mode: 'hsl',
     channel: 'h',
     theme: {},
-    readOnly: true
+    readOnly: false
   };
 
   constructor(props) {

--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -539,7 +539,7 @@ class ColorPickr extends React.Component {
               </div>
             )}
             <div {...theme('tileBackground', 'newSwatchContainer')}>
-            <div {...theme('swatch')} style={{ backgroundColor: rgbaBackground }} />
+              <div {...theme('swatch')} style={{ backgroundColor: rgbaBackground }} />
             </div>
           </div>
           <div {...theme('hexContainer')}>

--- a/src/components/inputs/h-input.js
+++ b/src/components/inputs/h-input.js
@@ -9,7 +9,8 @@ class HInput extends React.PureComponent {
     id: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    readOnly: PropTypes.bool.isRequired
   };
 
   render() {

--- a/src/components/inputs/h-input.js
+++ b/src/components/inputs/h-input.js
@@ -10,7 +10,7 @@ class HInput extends React.PureComponent {
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    readOnly: PropTypes.bool.isRequired
+    readOnly: PropTypes.bool
   };
 
   render() {

--- a/src/components/inputs/mode-input.js
+++ b/src/components/inputs/mode-input.js
@@ -11,7 +11,8 @@ class ModeInput extends React.PureComponent {
     name: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     checked: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    readOnly: PropTypes.bool.isRequired
   };
 
   onChange = () => {

--- a/src/components/inputs/mode-input.js
+++ b/src/components/inputs/mode-input.js
@@ -11,8 +11,7 @@ class ModeInput extends React.PureComponent {
     name: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     checked: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired,
-    readOnly: PropTypes.bool.isRequired
+    onChange: PropTypes.func.isRequired
   };
 
   onChange = () => {

--- a/src/components/inputs/number-input.js
+++ b/src/components/inputs/number-input.js
@@ -13,7 +13,7 @@ class NumberInput extends React.PureComponent {
     onChange: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
-    readOnly: PropTypes.bool.isRequired
+    readOnly: PropTypes.bool
   };
 
   onChange = e => {

--- a/src/components/inputs/number-input.js
+++ b/src/components/inputs/number-input.js
@@ -12,10 +12,11 @@ class NumberInput extends React.PureComponent {
     theme: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     min: PropTypes.number.isRequired,
-    max: PropTypes.number.isRequired
+    max: PropTypes.number.isRequired,
+    readOnly: PropTypes.bool.isRequired
   };
 
-  onChange = (e) => {
+  onChange = e => {
     const { id, onChange, max } = this.props;
     let value = parseInt(e.target.value || 0, 10);
 
@@ -26,11 +27,13 @@ class NumberInput extends React.PureComponent {
 
   render() {
     const theme = autokey(themeable(this.props.theme));
-    const { id, value, min, max } = this.props;
+    const { id, value, min, max, readOnly } = this.props;
+
     return (
       <div {...theme('numberInputContainer')}>
         <label {...theme('numberInputLabel')}>{id}</label>
         <input
+          readOnly={readOnly}
           {...theme('numberInput')}
           value={value}
           onChange={this.onChange}

--- a/src/components/inputs/rgb-input.js
+++ b/src/components/inputs/rgb-input.js
@@ -9,7 +9,8 @@ class RGBInput extends React.PureComponent {
     id: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    readOnly: PropTypes.bool.isRequired
   };
 
   render() {

--- a/src/components/inputs/rgb-input.js
+++ b/src/components/inputs/rgb-input.js
@@ -10,7 +10,7 @@ class RGBInput extends React.PureComponent {
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    readOnly: PropTypes.bool.isRequired
+    readOnly: PropTypes.bool
   };
 
   render() {

--- a/src/components/inputs/sl-alpha-input.js
+++ b/src/components/inputs/sl-alpha-input.js
@@ -10,7 +10,7 @@ class SLAlphaInput extends React.PureComponent {
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    readOnly: PropTypes.bool.isRequired
+    readOnly: PropTypes.bool
   };
 
   render() {

--- a/src/components/inputs/sl-alpha-input.js
+++ b/src/components/inputs/sl-alpha-input.js
@@ -9,7 +9,8 @@ class SLAlphaInput extends React.PureComponent {
     id: PropTypes.string.isRequired,
     theme: PropTypes.object.isRequired,
     value: PropTypes.number.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    readOnly: PropTypes.bool.isRequired
   };
 
   render() {

--- a/src/theme.js
+++ b/src/theme.js
@@ -32,7 +32,7 @@ export const defaultTheme = {
   xyControlDark: 'xy-control-dark',
   numberInputContainer: 'flex-child flex-child--grow relative',
   numberInputLabel: 'absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold',
-  numberInput: 'w-full pl18 pr3 input input--s txt-mono txt-xs bg-white',
+  numberInput: 'w-full pl18 pr3 input input--s txt-mono txt-xs',
   modeInputContainer: 'flex-child flex-child--no-shrink flex-parent flex-parent--center-cross w24',
   modeInput: 'cursor-pointer',
   swatch: 'w-full h-full',

--- a/test/jest/__snapshots__/colorpickr.jest.js.snap
+++ b/test/jest/__snapshots__/colorpickr.jest.js.snap
@@ -117,7 +117,6 @@ exports[`Colorpickr all options renders 1`] = `
         key="10"
       >
         <input
-          disabled={false}
           max={255}
           min={0}
           onChange={[Function]}
@@ -131,7 +130,6 @@ exports[`Colorpickr all options renders 1`] = `
         key="11"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -202,7 +200,6 @@ exports[`Colorpickr all options renders 1`] = `
             id="r"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -213,7 +210,6 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="r"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -233,7 +229,6 @@ exports[`Colorpickr all options renders 1`] = `
             id="g"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -244,7 +239,6 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="g"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -264,7 +258,6 @@ exports[`Colorpickr all options renders 1`] = `
             id="b"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -275,7 +268,6 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="b"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -294,7 +286,6 @@ exports[`Colorpickr all options renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -346,7 +337,6 @@ exports[`Colorpickr all options renders 1`] = `
         key="25"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="544945"
       />
@@ -472,7 +462,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -486,7 +475,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -557,7 +545,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -568,7 +555,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -588,7 +574,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -599,7 +584,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -619,7 +603,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -630,7 +613,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -649,7 +631,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -677,7 +658,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -721,7 +701,6 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="eeeeee"
       />
@@ -847,7 +826,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -861,7 +839,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -932,7 +909,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -943,7 +919,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -963,7 +938,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -974,7 +948,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -994,7 +967,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1005,7 +977,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1024,7 +995,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1052,7 +1022,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1096,7 +1065,6 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="eeef"
       />
@@ -1222,7 +1190,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1236,7 +1203,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -1307,7 +1273,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1318,7 +1283,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1338,7 +1302,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1349,7 +1312,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1369,7 +1331,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1380,7 +1341,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1399,7 +1359,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1427,7 +1386,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1471,7 +1429,6 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="eeeff"
       />
@@ -1597,7 +1554,6 @@ exports[`Colorpickr basic renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1611,7 +1567,6 @@ exports[`Colorpickr basic renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -1682,7 +1637,6 @@ exports[`Colorpickr basic renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1693,7 +1647,6 @@ exports[`Colorpickr basic renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1713,7 +1666,6 @@ exports[`Colorpickr basic renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1724,7 +1676,6 @@ exports[`Colorpickr basic renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1744,7 +1695,6 @@ exports[`Colorpickr basic renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1755,7 +1705,6 @@ exports[`Colorpickr basic renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1774,7 +1723,6 @@ exports[`Colorpickr basic renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1802,7 +1750,6 @@ exports[`Colorpickr basic renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1846,7 +1793,6 @@ exports[`Colorpickr basic renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="000"
       />
@@ -1972,7 +1918,6 @@ exports[`Colorpickr hex value renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1986,7 +1931,6 @@ exports[`Colorpickr hex value renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2057,7 +2001,6 @@ exports[`Colorpickr hex value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2068,7 +2011,6 @@ exports[`Colorpickr hex value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2088,7 +2030,6 @@ exports[`Colorpickr hex value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2099,7 +2040,6 @@ exports[`Colorpickr hex value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2119,7 +2059,6 @@ exports[`Colorpickr hex value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2130,7 +2069,6 @@ exports[`Colorpickr hex value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2149,7 +2087,6 @@ exports[`Colorpickr hex value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2177,7 +2114,6 @@ exports[`Colorpickr hex value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2221,7 +2157,6 @@ exports[`Colorpickr hex value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="33ffee"
       />
@@ -2347,7 +2282,6 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -2361,7 +2295,6 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2432,7 +2365,6 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2443,7 +2375,6 @@ exports[`Colorpickr hsl value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2463,7 +2394,6 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2474,7 +2404,6 @@ exports[`Colorpickr hsl value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2494,7 +2423,6 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2505,7 +2433,6 @@ exports[`Colorpickr hsl value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2524,7 +2451,6 @@ exports[`Colorpickr hsl value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2552,7 +2478,6 @@ exports[`Colorpickr hsl value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2596,7 +2521,6 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="e7e8e3"
       />
@@ -2722,7 +2646,6 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -2736,7 +2659,6 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2807,7 +2729,6 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2818,7 +2739,6 @@ exports[`Colorpickr hsla value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2838,7 +2758,6 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2849,7 +2768,6 @@ exports[`Colorpickr hsla value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2869,7 +2787,6 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2880,7 +2797,6 @@ exports[`Colorpickr hsla value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2899,7 +2815,6 @@ exports[`Colorpickr hsla value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2927,7 +2842,6 @@ exports[`Colorpickr hsla value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2971,7 +2885,6 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="00ffff"
       />
@@ -3470,7 +3383,6 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -3484,7 +3396,6 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -3555,7 +3466,6 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3566,7 +3476,6 @@ exports[`Colorpickr rgb value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3586,7 +3495,6 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3597,7 +3505,6 @@ exports[`Colorpickr rgb value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3617,7 +3524,6 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3628,7 +3534,6 @@ exports[`Colorpickr rgb value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3647,7 +3552,6 @@ exports[`Colorpickr rgb value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3675,7 +3579,6 @@ exports[`Colorpickr rgb value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -3719,7 +3622,6 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="00ffff"
       />
@@ -3845,7 +3747,6 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="7"
       >
         <input
-          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -3859,7 +3760,6 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="8"
       >
         <input
-          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -3930,7 +3830,6 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3941,7 +3840,6 @@ exports[`Colorpickr show hex value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3961,7 +3859,6 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3972,7 +3869,6 @@ exports[`Colorpickr show hex value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3992,7 +3888,6 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -4003,7 +3898,6 @@ exports[`Colorpickr show hex value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
-            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -4022,7 +3916,6 @@ exports[`Colorpickr show hex value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
-          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -4050,7 +3943,6 @@ exports[`Colorpickr show hex value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
-          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -4094,7 +3986,6 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
-        readOnly={false}
         type="text"
         value="3fe"
       />

--- a/test/jest/__snapshots__/colorpickr.jest.js.snap
+++ b/test/jest/__snapshots__/colorpickr.jest.js.snap
@@ -117,6 +117,7 @@ exports[`Colorpickr all options renders 1`] = `
         key="10"
       >
         <input
+          disabled={false}
           max={255}
           min={0}
           onChange={[Function]}
@@ -130,6 +131,7 @@ exports[`Colorpickr all options renders 1`] = `
         key="11"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -200,6 +202,7 @@ exports[`Colorpickr all options renders 1`] = `
             id="r"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -210,6 +213,7 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="r"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -229,6 +233,7 @@ exports[`Colorpickr all options renders 1`] = `
             id="g"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -239,6 +244,7 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="g"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -258,6 +264,7 @@ exports[`Colorpickr all options renders 1`] = `
             id="b"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -268,6 +275,7 @@ exports[`Colorpickr all options renders 1`] = `
           <RGBInput
             id="b"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -286,6 +294,7 @@ exports[`Colorpickr all options renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -337,6 +346,7 @@ exports[`Colorpickr all options renders 1`] = `
         key="25"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="544945"
       />
@@ -462,6 +472,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -475,6 +486,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -545,6 +557,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -555,6 +568,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -574,6 +588,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -584,6 +599,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -603,6 +619,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -613,6 +630,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -631,6 +649,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -658,6 +677,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -701,6 +721,7 @@ exports[`Colorpickr basic hex input adjusts value onBlur 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="eeeeee"
       />
@@ -826,6 +847,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -839,6 +861,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -909,6 +932,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -919,6 +943,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -938,6 +963,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -948,6 +974,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -967,6 +994,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -977,6 +1005,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -995,6 +1024,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1022,6 +1052,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1065,6 +1096,7 @@ exports[`Colorpickr basic hex input returns value onChange 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="eeef"
       />
@@ -1190,6 +1222,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1203,6 +1236,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -1273,6 +1307,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1283,6 +1318,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1302,6 +1338,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1312,6 +1349,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1331,6 +1369,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1341,6 +1380,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1359,6 +1399,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1386,6 +1427,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1429,6 +1471,7 @@ exports[`Colorpickr basic invalid hex input does not fire onChange 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="eeeff"
       />
@@ -1554,6 +1597,7 @@ exports[`Colorpickr basic renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1567,6 +1611,7 @@ exports[`Colorpickr basic renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -1637,6 +1682,7 @@ exports[`Colorpickr basic renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1647,6 +1693,7 @@ exports[`Colorpickr basic renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1666,6 +1713,7 @@ exports[`Colorpickr basic renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1676,6 +1724,7 @@ exports[`Colorpickr basic renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1695,6 +1744,7 @@ exports[`Colorpickr basic renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -1705,6 +1755,7 @@ exports[`Colorpickr basic renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1723,6 +1774,7 @@ exports[`Colorpickr basic renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -1750,6 +1802,7 @@ exports[`Colorpickr basic renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -1793,6 +1846,7 @@ exports[`Colorpickr basic renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="000"
       />
@@ -1918,6 +1972,7 @@ exports[`Colorpickr hex value renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -1931,6 +1986,7 @@ exports[`Colorpickr hex value renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2001,6 +2057,7 @@ exports[`Colorpickr hex value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2011,6 +2068,7 @@ exports[`Colorpickr hex value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2030,6 +2088,7 @@ exports[`Colorpickr hex value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2040,6 +2099,7 @@ exports[`Colorpickr hex value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2059,6 +2119,7 @@ exports[`Colorpickr hex value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2069,6 +2130,7 @@ exports[`Colorpickr hex value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2087,6 +2149,7 @@ exports[`Colorpickr hex value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2114,6 +2177,7 @@ exports[`Colorpickr hex value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2157,6 +2221,7 @@ exports[`Colorpickr hex value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="33ffee"
       />
@@ -2282,6 +2347,7 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -2295,6 +2361,7 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2365,6 +2432,7 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2375,6 +2443,7 @@ exports[`Colorpickr hsl value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2394,6 +2463,7 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2404,6 +2474,7 @@ exports[`Colorpickr hsl value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2423,6 +2494,7 @@ exports[`Colorpickr hsl value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2433,6 +2505,7 @@ exports[`Colorpickr hsl value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2451,6 +2524,7 @@ exports[`Colorpickr hsl value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2478,6 +2552,7 @@ exports[`Colorpickr hsl value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2521,6 +2596,7 @@ exports[`Colorpickr hsl value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="e7e8e3"
       />
@@ -2646,6 +2722,7 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -2659,6 +2736,7 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -2729,6 +2807,7 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2739,6 +2818,7 @@ exports[`Colorpickr hsla value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2758,6 +2838,7 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2768,6 +2849,7 @@ exports[`Colorpickr hsla value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2787,6 +2869,7 @@ exports[`Colorpickr hsla value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -2797,6 +2880,7 @@ exports[`Colorpickr hsla value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2815,6 +2899,7 @@ exports[`Colorpickr hsla value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -2842,6 +2927,7 @@ exports[`Colorpickr hsla value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -2885,8 +2971,382 @@ exports[`Colorpickr hsla value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="00ffff"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Colorpickr read only renders 1`] = `
+<div
+  className="colorpickr round inline-block bg-gray-faint w240 round px12 py12 txt-xs"
+  key="4"
+>
+  <div
+    className="flex-parent relative"
+    key="5"
+  >
+    <div
+      className="flex-child flex-child--no-shrink pb12 h120 w120 z1"
+      key="6"
+    >
+      <XYControl
+        isDark="dark"
+        onChange={[Function]}
+        theme={
+          Object {
+            "xyControl": "xy-control absolute z1 unselectable cursor-move",
+            "xyControlContainer": "relative w-full h-full cursor-pointer events-none",
+            "xyControlDark": "xy-control-dark",
+          }
+        }
+        x={0}
+        xmax={100}
+        y={100}
+        ymax={100}
+      >
+        <RGBGradient
+          active={false}
+          color="r"
+          opacityHigh={0}
+          opacityLow={0}
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientBHigh": "gradient-rgb gradient-b-high",
+              "gradientBLow": "gradient-rgb gradient-b-low",
+              "gradientGHigh": "gradient-rgb gradient-g-high",
+              "gradientGLow": "gradient-rgb gradient-g-low",
+              "gradientRHigh": "gradient-rgb gradient-r-high",
+              "gradientRLow": "gradient-rgb gradient-r-low",
+            }
+          }
+        />
+        <RGBGradient
+          active={false}
+          color="g"
+          opacityHigh={0}
+          opacityLow={0}
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientBHigh": "gradient-rgb gradient-b-high",
+              "gradientBLow": "gradient-rgb gradient-b-low",
+              "gradientGHigh": "gradient-rgb gradient-g-high",
+              "gradientGLow": "gradient-rgb gradient-g-low",
+              "gradientRHigh": "gradient-rgb gradient-r-high",
+              "gradientRLow": "gradient-rgb gradient-r-low",
+            }
+          }
+        />
+        <RGBGradient
+          active={false}
+          color="b"
+          opacityHigh={0}
+          opacityLow={0}
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientBHigh": "gradient-rgb gradient-b-high",
+              "gradientBLow": "gradient-rgb gradient-b-low",
+              "gradientGHigh": "gradient-rgb gradient-g-high",
+              "gradientGLow": "gradient-rgb gradient-g-low",
+              "gradientRHigh": "gradient-rgb gradient-r-high",
+              "gradientRLow": "gradient-rgb gradient-r-low",
+            }
+          }
+        />
+        <HGradient
+          active={true}
+          hueBackground="hsl(0, 100%, 50%)"
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientHue": "gradient-hue",
+            }
+          }
+        />
+        <SGradient
+          active={false}
+          opacityHigh={0}
+          opacityLow={0}
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientSaturation": "gradient-saturation",
+            }
+          }
+        />
+        <LGradient
+          active={false}
+          opacityHigh={0}
+          opacityLow={0}
+          theme={
+            Object {
+              "gradient": "absolute top right bottom left",
+              "gradientLight": "gradient-light",
+            }
+          }
+        />
+      </XYControl>
+      <div
+        className="slider colormode-slider colormode-slider-h"
+        key="7"
+      >
+        <input
+          disabled={true}
+          max={360}
+          min={0}
+          onChange={[Function]}
+          style={Object {}}
+          type="range"
+          value={0}
+        />
+      </div>
+      <div
+        className="slider bg-tile bg-white"
+        key="8"
+      >
+        <input
+          disabled={true}
+          max={100}
+          min={0}
+          onChange={[Function]}
+          style={
+            Object {
+              "background": "linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1))",
+            }
+          }
+          type="range"
+          value={100}
+        />
+      </div>
+    </div>
+    <div
+      className="flex-child flex-child--grow ml12"
+      key="9"
+    >
+      <div
+        className="toggle-group w-full mb12"
+        key="10"
+      >
+        <label
+          className="toggle-container w-full"
+          key="11"
+        >
+          <input
+            checked={true}
+            data-test="mode-hsl"
+            name="toggle"
+            onChange={[Function]}
+            type="radio"
+            value="hsl"
+          />
+          <div
+            className="toggle py0 px6 toggle--gray"
+            key="12"
+          >
+            HSL
+          </div>
+        </label>
+        <label
+          className="toggle-container w-full"
+          key="13"
+        >
+          <input
+            checked={false}
+            data-test="mode-rgb"
+            name="toggle"
+            onChange={[Function]}
+            type="radio"
+            value="rgb"
+          />
+          <div
+            className="toggle py0 px6 toggle--gray"
+            key="14"
+          >
+            RGB
+          </div>
+        </label>
+      </div>
+      <div>
+        <div
+          className="mb3 flex-parent is-active"
+          key="1"
+        >
+          <ModeInput
+            checked={true}
+            id="h"
+            name=""
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "modeInput": "cursor-pointer",
+                "modeInputContainer": "flex-child flex-child--no-shrink flex-parent flex-parent--center-cross w24",
+              }
+            }
+          />
+          <HInput
+            id="h"
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs",
+                "numberInputContainer": "flex-child flex-child--grow relative",
+                "numberInputLabel": "absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold",
+              }
+            }
+            value={0}
+          />
+        </div>
+        <div
+          className="mb3 flex-parent"
+          key="2"
+        >
+          <ModeInput
+            checked={false}
+            id="s"
+            name=""
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "modeInput": "cursor-pointer",
+                "modeInputContainer": "flex-child flex-child--no-shrink flex-parent flex-parent--center-cross w24",
+              }
+            }
+          />
+          <SLAlphaInput
+            id="s"
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs",
+                "numberInputContainer": "flex-child flex-child--grow relative",
+                "numberInputLabel": "absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold",
+              }
+            }
+            value={0}
+          />
+        </div>
+        <div
+          className="mb3 flex-parent"
+          key="3"
+        >
+          <ModeInput
+            checked={false}
+            id="l"
+            name=""
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "modeInput": "cursor-pointer",
+                "modeInputContainer": "flex-child flex-child--no-shrink flex-parent flex-parent--center-cross w24",
+              }
+            }
+          />
+          <SLAlphaInput
+            id="l"
+            onChange={[Function]}
+            readOnly={true}
+            theme={
+              Object {
+                "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs",
+                "numberInputContainer": "flex-child flex-child--grow relative",
+                "numberInputLabel": "absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold",
+              }
+            }
+            value={0}
+          />
+        </div>
+      </div>
+      <div
+        className="mb3"
+        key="15"
+      >
+        <SLAlphaInput
+          id="α"
+          onChange={[Function]}
+          readOnly={true}
+          theme={
+            Object {
+              "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs",
+              "numberInputContainer": "flex-child flex-child--grow relative",
+              "numberInputLabel": "absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold",
+            }
+          }
+          value={100}
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="flex-parent mt6"
+    key="16"
+  >
+    <div
+      className="flex-child flex-child--no-shrink grid w120 round scroll-hidden"
+      key="17"
+    >
+      <div
+        className="bg-tile bg-white col h24 border-r border--gray-faint"
+        key="18"
+      >
+        <button
+          className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
+          data-test="color-reset"
+          disabled={true}
+          key="19"
+          onClick={[Function]}
+          style={
+            Object {
+              "backgroundColor": "#000",
+            }
+          }
+          title="Reset color"
+        />
+      </div>
+      <div
+        className="bg-tile bg-white col h24"
+        key="20"
+      >
+        <div
+          className="w-full h-full"
+          key="21"
+          style={
+            Object {
+              "backgroundColor": "rgba(0,0,0,1)",
+            }
+          }
+        />
+      </div>
+    </div>
+    <div
+      className="flex-child flex-child--grow ml12 relative"
+      key="22"
+    >
+      <label
+        className="absolute top left bottom pl6 flex-parent flex-parent--center-cross color-gray-light txt-bold"
+        key="23"
+      >
+        #
+      </label>
+      <input
+        className="w-full pl18 pr3 input input--s txt-mono txt-xs"
+        data-test="hex-input"
+        key="24"
+        onBlur={[Function]}
+        onChange={[Function]}
+        readOnly={true}
+        type="text"
+        value="000"
       />
     </div>
   </div>
@@ -3010,6 +3470,7 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -3023,6 +3484,7 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -3093,6 +3555,7 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3103,6 +3566,7 @@ exports[`Colorpickr rgb value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3122,6 +3586,7 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3132,6 +3597,7 @@ exports[`Colorpickr rgb value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3151,6 +3617,7 @@ exports[`Colorpickr rgb value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3161,6 +3628,7 @@ exports[`Colorpickr rgb value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3179,6 +3647,7 @@ exports[`Colorpickr rgb value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3206,6 +3675,7 @@ exports[`Colorpickr rgb value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -3249,6 +3719,7 @@ exports[`Colorpickr rgb value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="00ffff"
       />
@@ -3374,6 +3845,7 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="7"
       >
         <input
+          disabled={false}
           max={360}
           min={0}
           onChange={[Function]}
@@ -3387,6 +3859,7 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="8"
       >
         <input
+          disabled={false}
           max={100}
           min={0}
           onChange={[Function]}
@@ -3457,6 +3930,7 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="h"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3467,6 +3941,7 @@ exports[`Colorpickr show hex value renders 1`] = `
           <HInput
             id="h"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3486,6 +3961,7 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="s"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3496,6 +3972,7 @@ exports[`Colorpickr show hex value renders 1`] = `
           <SLAlphaInput
             id="s"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3515,6 +3992,7 @@ exports[`Colorpickr show hex value renders 1`] = `
             id="l"
             name=""
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "modeInput": "cursor-pointer",
@@ -3525,6 +4003,7 @@ exports[`Colorpickr show hex value renders 1`] = `
           <SLAlphaInput
             id="l"
             onChange={[Function]}
+            readOnly={false}
             theme={
               Object {
                 "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3543,6 +4022,7 @@ exports[`Colorpickr show hex value renders 1`] = `
         <SLAlphaInput
           id="α"
           onChange={[Function]}
+          readOnly={false}
           theme={
             Object {
               "numberInput": "w-full pl18 pr3 input input--s txt-mono txt-xs bg-white",
@@ -3570,6 +4050,7 @@ exports[`Colorpickr show hex value renders 1`] = `
         <button
           className="w-full h-full txt-bold align-center color-transparent color-white-on-hover transition"
           data-test="color-reset"
+          disabled={false}
           key="19"
           onClick={[Function]}
           style={
@@ -3613,6 +4094,7 @@ exports[`Colorpickr show hex value renders 1`] = `
         key="24"
         onBlur={[Function]}
         onChange={[Function]}
+        readOnly={false}
         type="text"
         value="3fe"
       />

--- a/test/jest/colorpickr.jest.js
+++ b/test/jest/colorpickr.jest.js
@@ -128,6 +128,19 @@ describe('Colorpickr', () => {
     });
   });
 
+  // ------------------------------------------------------------------------------------
+  describe(testCases.readOnly.description, () => {
+    beforeEach(() => {
+      testCase = testCases.readOnly;
+      wrapper = shallow(React.createElement(testCase.component, testCase.props));
+    });
+
+    test('renders', () => {
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+  });
+  // ------------------------------------------------------------------------------------
+
   describe(testCases.hexValue.description, () => {
     beforeEach(() => {
       testCase = testCases.hexValue;

--- a/test/jest/colorpickr.jest.js
+++ b/test/jest/colorpickr.jest.js
@@ -128,7 +128,6 @@ describe('Colorpickr', () => {
     });
   });
 
-  // ------------------------------------------------------------------------------------
   describe(testCases.readOnly.description, () => {
     beforeEach(() => {
       testCase = testCases.readOnly;
@@ -139,7 +138,6 @@ describe('Colorpickr', () => {
       expect(toJson(wrapper)).toMatchSnapshot();
     });
   });
-  // ------------------------------------------------------------------------------------
 
   describe(testCases.hexValue.description, () => {
     beforeEach(() => {

--- a/test/test-cases/colorpickr-test-cases.js
+++ b/test/test-cases/colorpickr-test-cases.js
@@ -11,6 +11,15 @@ export const basic = {
   }
 };
 
+export const readOnly = {
+  description: 'read only',
+  component: ColorPickr,
+  props: {
+    onChange: safeSpy(),
+    readOnly: true
+  }
+};
+
 export const hexValue = {
   description: 'hex value',
   component: ColorPickr,


### PR DESCRIPTION
Adds a `readOnly` prop to the color picker to give it a readonly state. There may be a few unrelated formatting diffs due to prettier but nothing big (let me know if that is distracting). Prompted by work downstream on [using readonly states in our Studio UI widgets for component layer properties](https://github.com/mapbox/studio/issues/12697).