### PR TITLE
Disable radio buttons when the color picker is read only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.0.2
+
+- [Enhancement] Allow ModeInput to have a disabled state based on a readOnly prop
 ## 9.0.1
 
 - [Bug] Fix click to select color resulting in drag behavior [#153](https://github.com/mapbox/react-colorpickr/pull/153)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/react-colorpickr",
-  "version": "9.0.0",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/react-colorpickr",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "A React colorpicker",
   "main": "dist/colorpickr.js",
   "scripts": {

--- a/src/__snapshots__/colorpickr.test.js.snap
+++ b/src/__snapshots__/colorpickr.test.js.snap
@@ -106,6 +106,7 @@ exports[`Colorpickr readOnly renders 1`] = `
                 <input
                   checked=""
                   class="cursor-pointer"
+                  disabled=""
                   name=""
                   type="radio"
                 />
@@ -139,6 +140,7 @@ exports[`Colorpickr readOnly renders 1`] = `
               >
                 <input
                   class="cursor-pointer"
+                  disabled=""
                   name=""
                   type="radio"
                 />
@@ -172,6 +174,7 @@ exports[`Colorpickr readOnly renders 1`] = `
               >
                 <input
                   class="cursor-pointer"
+                  disabled=""
                   name=""
                   type="radio"
                 />

--- a/src/components/inputs/mode-input.js
+++ b/src/components/inputs/mode-input.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import themeable from 'react-themeable';
 import { autokey } from '../../autokey';
 
-function ModeInput({ name, theme, checked, onChange }) {
+function ModeInput({ name, theme, checked, onChange, readOnly }) {
   const themer = autokey(themeable(theme));
   return (
     <div {...themer('modeInputContainer')}>
@@ -13,16 +13,22 @@ function ModeInput({ name, theme, checked, onChange }) {
         name={name}
         checked={checked}
         onChange={onChange}
+        disabled={readOnly}
       />
     </div>
   );
 }
 
+ModeInput.defaultProps = {
+  readOnly: false
+};
+
 ModeInput.propTypes = {
   name: PropTypes.string.isRequired,
   theme: PropTypes.object.isRequired,
   checked: PropTypes.bool.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool
 };
 
 export { ModeInput };


### PR DESCRIPTION
The radio buttons cannot be clicked when the color picker is in readOnly mode. Unblocks https://github.com/mapbox/studio/issues/15312