### PR TITLE
Fix hex input overriding alpha value

### DIFF
--- a/src/colorpickr.js
+++ b/src/colorpickr.js
@@ -155,7 +155,9 @@ class ColorPickr extends React.Component {
     const value = normalizeString(e.target.value);
     const hex = `#${value}`;
     const isValid = colorString.get(hex);
+    const pastAlpha = this.state.color.a;
     const color = this.assignColor(hex) || this.state.color;
+    color.a = pastAlpha;
     const nextColor = { ...color, ...{ hex: value } };
     this.setState({ color: nextColor }, () => {
       if (isValid) this.emitOnChange(true);
@@ -167,7 +169,9 @@ class ColorPickr extends React.Component {
 
     // If an invalid hex value remains `onBlur`, correct course by calling
     // `getColor` which will return a valid one to us.
+    const pastAlpha = this.state.color.a;
     const nextColor = this.assignColor(hex) || this.state.color;
+    nextColor.a = pastAlpha;
     this.setState({ color: nextColor }, this.emitOnChange.bind(this, true));
   };
 

--- a/src/colorpickr.test.js
+++ b/src/colorpickr.test.js
@@ -116,33 +116,6 @@ describe('Colorpickr', () => {
       expect(element).toBeTruthy();
     });
 
-    test('hex input retains alpha value onChange', () => {
-      props.initialValue = 'hsla(0, 0%, 20%, 0.5)';
-
-      const mockEvent = {
-        target: {
-          value: '#333'
-        }
-      };
-
-      const input = wrapper.getByTestId('hex-input');
-      fireEvent.change(input, mockEvent);
-      expect(props.onChange).toHaveBeenCalledTimes(1);
-      expect(props.onChange).toHaveBeenCalledWith({
-        h: 0,
-        s: 0,
-        l: 20,
-        r: 51,
-        g: 51,
-        b: 51,
-        a: 1,
-        hexInput: true,
-        hex: '333',
-        mode: 'hsl',
-        channel: 'h'
-      });
-    });
-
     afterEach(() => {
       jest.clearAllMocks();
     });
@@ -276,6 +249,37 @@ describe('Colorpickr', () => {
       const { getByTestId } = render(<ColorPickr {...props} />);
       const element = getByTestId('hex-input');
       expect(element.value).toEqual('3fe');
+    });
+
+    test('hex value maintains alpha onChange', () => {
+      const props = {
+        initialValue: 'hsla(100, 50%, 40%, 0.5)',
+        onChange: jest.fn()
+      };
+
+      const { getByTestId } = render(<ColorPickr {...props} />);
+      const mockEvent = {
+        target: {
+          value: '#333'
+        }
+      };
+
+      const input = getByTestId('hex-input');
+      fireEvent.change(input, mockEvent);
+      expect(props.onChange).toHaveBeenCalledTimes(1);
+      expect(props.onChange).toHaveBeenCalledWith({
+        h: 0,
+        s: 0,
+        l: 20,
+        r: 51,
+        g: 51,
+        b: 51,
+        a: 0.5,
+        hexInput: true,
+        hex: '333',
+        mode: 'hsl',
+        channel: 'h'
+      });
     });
   });
 

--- a/src/colorpickr.test.js
+++ b/src/colorpickr.test.js
@@ -116,6 +116,33 @@ describe('Colorpickr', () => {
       expect(element).toBeTruthy();
     });
 
+    test('hex input retains alpha value onChange', () => {
+      props.initialValue = 'hsla(0, 0%, 20%, 0.5)';
+
+      const mockEvent = {
+        target: {
+          value: '#333'
+        }
+      };
+
+      const input = wrapper.getByTestId('hex-input');
+      fireEvent.change(input, mockEvent);
+      expect(props.onChange).toHaveBeenCalledTimes(1);
+      expect(props.onChange).toHaveBeenCalledWith({
+        h: 0,
+        s: 0,
+        l: 20,
+        r: 51,
+        g: 51,
+        b: 51,
+        a: 1,
+        hexInput: true,
+        hex: '333',
+        mode: 'hsl',
+        channel: 'h'
+      });
+    });
+
     afterEach(() => {
       jest.clearAllMocks();
     });


### PR DESCRIPTION
Fix for https://github.com/mapbox/studio/issues/13487

### QA steps:
- [x] Set alpha value
- [x] Change color via hex input
- [x] Alpha should be the same as it was

@tristen for review

