### PR TITLE
Add optional emitOnChange param to override method

### DIFF
--- a/src/colorpickr.test.tsx
+++ b/src/colorpickr.test.tsx
@@ -103,7 +103,11 @@ describe('Colorpickr', () => {
 
   describe('overrides', () => {
     interface MockedInstance {
-      overrideValue: (v: string, updateInit?: boolean) => void;
+      overrideValue: (
+        v: string,
+        updateInit?: boolean,
+        emitOnChange?: boolean
+      ) => void;
     }
 
     let mockedInstance: MockedInstance;
@@ -152,6 +156,13 @@ describe('Colorpickr', () => {
         mode: 'disc'
       });
 
+      const element = screen.getByTestId('color-reset');
+      expect(element.style.backgroundColor).toEqual('rgb(255, 0, 0)');
+    });
+
+    test('emitOnChange: false does not invoke onChange handler', () => {
+      mockedInstance.overrideValue('red', true, false);
+      expect(props.onChange).not.toHaveBeenCalled();
       const element = screen.getByTestId('color-reset');
       expect(element.style.backgroundColor).toEqual('rgb(255, 0, 0)');
     });

--- a/src/colorpickr.tsx
+++ b/src/colorpickr.tsx
@@ -115,12 +115,17 @@ class ColorPickr extends React.Component<Props, State> {
     }
   }
 
-  overrideValue = (cssColor: 'string', shouldUpdateInitialValue: boolean) => {
+  overrideValue = (
+    cssColor: 'string',
+    shouldUpdateInitialValue: boolean,
+    emitOnChange = true
+  ) => {
     const color = this.assignColor(cssColor);
+    const cb = () => emitOnChange && this.emitOnChange();
     if (shouldUpdateInitialValue) {
-      this.setState({ color, initialValue: color }, this.emitOnChange);
+      this.setState({ color, initialValue: color }, cb);
     } else {
-      this.setState({ color }, this.emitOnChange);
+      this.setState({ color }, cb);
     }
   };
 


### PR DESCRIPTION
Helps the picker from being noisy when an onChange event is unnecessary